### PR TITLE
Add built-in hijri converter

### DIFF
--- a/multicalendar.inx
+++ b/multicalendar.inx
@@ -23,6 +23,7 @@
             </param>
             <label appearance="header">Advanced Settings:</label>
             <param name="enable-hijri" type="bool" gui-text="Include Hijri Calendar">false</param>
+            <param name="adjust-hijri-date" type="int" min="-5" max="5" gui-text="Adjust Hijri Day:">0</param>
             <param name="use-farsi-day" type="bool" gui-text="Use Farsi numbering symbol instead of Arabic number in Hijri days">false</param>
         </page>
         <page name="colors" gui-text="Colors">

--- a/multicalendar.py
+++ b/multicalendar.py
@@ -403,7 +403,6 @@ class Calendar(inkex.EffectExtension):
         return cal2
     
     def gregorian_to_hijri(self, yg, mg, dg):
-        # return convert.Gregorian(yg, mg, dg).to_hijri()
         dg -= 1
         if(mg<3):
             yg -= 1
@@ -436,6 +435,7 @@ class Calendar(inkex.EffectExtension):
         if(im==13):
             im = 12
         id = z-floor(29.5001*im-29)
+
         date = [iy, im, id]
         return date
 

--- a/multicalendar.py
+++ b/multicalendar.py
@@ -31,7 +31,7 @@ http://en.wikipedia.org/wiki/ISO_week_date
 
 __version__ = "0.3"
 
-# import datetime
+import datetime
 import calendar
 import re
 import sys
@@ -42,6 +42,7 @@ import inkex
 from inkex import TextElement
 
 # from hijri_converter import convert
+from multicalendar_libs import convert
 from math import ceil, floor
 
 if sys.version_info[0] > 2:
@@ -156,6 +157,9 @@ class Calendar(inkex.EffectExtension):
         pars.add_argument(
             "--enable-hijri", type=inkex.Boolean, dest="enable_hijri", default=False,
             help='Include Hijri Calendar')
+        pars.add_argument(
+            "--adjust-hijri-date", type=int, dest="adjust_hijri_date", default=0,
+            help="Adjust the day if it is too fast or too late some days.")
         pars.add_argument(
             "--use-farsi-day", type=inkex.Boolean, dest="use_farsi_day", default=False,
             help='Use Farsi numbering symbol instead of arabic number')
@@ -398,46 +402,9 @@ class Calendar(inkex.EffectExtension):
                 if day == 0:
                     weekcal.append(day)
                 else:
-                    weekcal.append(self.gregorian_to_hijri(y, m, day))
+                    weekcal.append(convert.Gregorian(y, m, day, self.options.adjust_hijri_date).to_hijri())
             cal2.append(weekcal)
         return cal2
-    
-    def gregorian_to_hijri(self, yg, mg, dg):
-        dg -= 1
-        if(mg<3):
-            yg -= 1
-            mg += 12
-        a = floor(yg/100.0)
-        b = 2-a+floor(a/4.0)
-        if (yg<1583):
-            b = 0
-        if (yg==1582):
-            if (mg>10):
-                b = -10
-            if (mg==10):
-                b = 0
-                if (dg>4):
-                    b = -10
-                    
-        jd = floor(365.25*(yg+4716))+floor(30.6001*(mg+1))+dg+b-1524
-
-        iyear = 10631.0/30.0
-        epochastro = 1948084
-        shift1 = 8.01/60.0
-        
-        z = jd-epochastro
-        cyc = floor(z/10631.0)
-        z -= 10631*cyc
-        j = floor((z-shift1)/iyear)
-        iy = 30*cyc+j
-        z -= floor(j*iyear+shift1)
-        im = floor((z+28.5001)/29.5)
-        if(im==13):
-            im = 12
-        id = z-floor(29.5001*im-29)
-
-        date = [iy, im, id]
-        return date
 
     def create_month(self, m):
         txt_atts = {

--- a/multicalendar_libs/convert.py
+++ b/multicalendar_libs/convert.py
@@ -1,0 +1,67 @@
+import datetime
+import inkex
+from math import floor
+
+class Gregorian:
+    def __init__(self, year, month, day, adjust):
+        self.year = year
+        self.month = month
+        self.day = day
+        self.adjust = adjust
+        
+    def to_julian(self):
+        adjust = datetime.datetime(self.year, self.month, self.day) - datetime.timedelta(self.adjust)
+        jd = adjust.toordinal() + 1721425
+        return jd
+
+    def to_hijri(self):
+        date = self.to_julian()
+        return Julian(date).to_hijri()
+
+class Julian:
+    def __init__(self, jd, adjust=0):
+        self.jd = jd
+        self.adjust = adjust
+
+    def to_hijri(self):
+        iyear = 10631.0/30.0
+        epochastro = 1948084
+        shift1 = 8.01/60.0
+
+        z = self.jd - epochastro
+        cyc = floor(z / 10631.0)
+        z -= 10631 * cyc
+        j = floor((z - shift1) / iyear)
+        iy = 30 * cyc + j
+        z -= floor(j * iyear + shift1)
+        im = floor((z + 28.5001) / 29.5)
+        if(im==13):
+            im = 12
+        id = z - floor(29.5001 * im - 29)
+
+        date = [iy, im, id]
+        return date
+
+    def to_gregorian(self):
+        gdate = datetime.date.fromordinal(self.jd - 1721425) - datetime.timedelta(self.adjust)
+        yg = gdate.year
+        mg = gdate.month
+        dg = gdate.day
+
+        date = [yg, mg, dg]
+        return date
+
+class Hijri:
+    def __init__(self, year, month, day, adjust):
+        self.year = year
+        self.month = month
+        self.day = day
+        self.adjust = adjust
+
+    def to_julian(self):
+        jd = floor((11 * self.year + 3) / 30) + floor(354 * self.year) + floor(30 * self.month) - floor((self.month - 1) / 2) + self.day + 1948440 - 386
+        return jd
+
+    def to_gregorian(self):
+        date = self.to_julian()
+        return Julian(date, self.adjust).to_gregorian()


### PR DESCRIPTION
Based on [this](https://www.al-habib.info/islamic-calendar/hijricalendartext.htm) JavaScript Code

This allows windows users to use this extension without `pip3`